### PR TITLE
Sisyphus1

### DIFF
--- a/internal/cmd/cli.go
+++ b/internal/cmd/cli.go
@@ -36,7 +36,7 @@ func CmdInit(Version, GitCommit, BuildTime string) *config.Red_t {
 		Use:           "red-cli <command> <subcommand> [flags]",
 		Short:         "Redmine CLI",
 		Long:          `Redmine CLI for integration with Redmine API`,
-		Version:       Version + "\nGit Commit: " + GitCommit + "\nBuild time: " + BuildTime,
+		Version:       Version + "\nGit Commit: " + GitCommit,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Run:           func(cmd *cobra.Command, args []string) { cmd.Help() },

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ BIN_FOLDER=build/
 GIT_COMMIT ?= $(shell { git stash create; git rev-parse HEAD; } | grep -Exm1 '[[:xdigit:]]{40}')
 VERSION ?= $(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
 
-BIN_TARGET=$(BIN_FOLDER)$(BIN_NAME)-$(VERSION)$(EXE)
+BIN_TARGET=$(BIN_FOLDER)$(BIN_NAME)$(EXE)
 
 export FLAGS += -X "main.Version=$(VERSION)"
 export FLAGS += -X "main.GitCommit=$(GIT_COMMIT)"

--- a/makefile
+++ b/makefile
@@ -30,7 +30,6 @@ BIN_TARGET=$(BIN_FOLDER)$(BIN_NAME)$(EXE)
 
 export FLAGS += -X "main.version=$(VERSION)"
 export FLAGS += -X "main.commit=$(GIT_COMMIT)"
-export FLAGS += -X "main.BuildTime=$(shell date)"
 
 all: test build
 

--- a/makefile
+++ b/makefile
@@ -28,8 +28,8 @@ VERSION ?= $(shell git symbolic-ref -q --short HEAD || git describe --tags --exa
 
 BIN_TARGET=$(BIN_FOLDER)$(BIN_NAME)$(EXE)
 
-export FLAGS += -X "main.Version=$(VERSION)"
-export FLAGS += -X "main.GitCommit=$(GIT_COMMIT)"
+export FLAGS += -X "main.version=$(VERSION)"
+export FLAGS += -X "main.commit=$(GIT_COMMIT)"
 export FLAGS += -X "main.BuildTime=$(shell date)"
 
 all: test build


### PR DESCRIPTION
Hello! I am the maintainer of Alt Linux and I want to build your package into the repository. 

When building I encountered such problems as version, commit and build time not being displayed. This is due to the fact that the variable names in your makefile do not match the names in main.go. 

You should also remove the build date from your code, because build reproducibility is important for Linux distributions. This means that the hash sum of the file that is generated during the build should not differ each time when rebuilding, in your case it will differ because the variable will contain different lines each time.

Please remove the message "Can't read config file in root" if the user has never logged into their account. This is logically incorrect! Since this file is then generated. Make it so that it is displayed when the user has already logged in but the file is missing.

 The last thing worth saying is that the name of the file that will be in /usr/bin should not contain the version, this is unnecessary and is a gross mistake. Please make changes, good luck and successful development of the product!

result before: 

red-cli-0.1.6 -v
Can't read config file in root
Redmine CLI (red-cli) v0.0.0-dev

result after:

red-cli -v
Can't read config file in root
red-cli version 0.1.6
Git Commit: 111c09e6b6f13108f805d178ea9502584ba58d92



